### PR TITLE
Catch ClientHandlerException on DropboxHandler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.mule.modules</groupId>
 	<artifactId>mule-module-dropbox</artifactId>
-	<version>3.3.4-SNAPSHOT</version>
+	<version>3.3.3</version>
 	<packaging>mule-module</packaging>
 	<name>Mule Dropbox Cloud Connector</name>
 	<description>Connector for accessing, creating folders and files in dropbox. Uses OAuth2 for authentication.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.mule.modules</groupId>
 	<artifactId>mule-module-dropbox</artifactId>
-	<version>3.3.3</version>
+	<version>3.3.4-SNAPSHOT</version>
 	<packaging>mule-module</packaging>
 	<name>Mule Dropbox Cloud Connector</name>
 	<description>Connector for accessing, creating folders and files in dropbox. Uses OAuth2 for authentication.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.mule.modules</groupId>
 	<artifactId>mule-module-dropbox</artifactId>
-	<version>3.3.3-SNAPSHOT</version>
+	<version>3.3.4-SNAPSHOT</version>
 	<packaging>mule-module</packaging>
 	<name>Mule Dropbox Cloud Connector</name>
 	<description>Connector for accessing, creating folders and files in dropbox. Uses OAuth2 for authentication.</description>


### PR DESCRIPTION
response does not have an entity Error and this cause a ClientHandlerException. This patch is to catch the ClientHandlerException and throw a DropboxExcetion with the response (in order to know what is causing this).
